### PR TITLE
Fix Regression: cannot write on subfolder just created in shared

### DIFF
--- a/roles/nethcfg/tasks/samba.yml
+++ b/roles/nethcfg/tasks/samba.yml
@@ -86,12 +86,12 @@
   register: chk_shared
 
 - name: Copying default templates for shared template type
-  shell: cp -r /etc/e-smith/templates/etc/samba/smb.conf/ibay-default /etc/e-smith/templates-custom/etc/samba/smb.conf/ibay-shared
+  shell: cp -r /etc/e-smith/templates/etc/samba/smb.conf/ibay-default /etc/e-smith/templates/etc/samba/smb.conf/ibay-shared
   when: force_ibay_shared|bool or chk_shared|failed
 
 - name: Configuring ibay-shared template structure (directory mask)
   lineinfile:
-    dest: /etc/e-smith/templates-custom/etc/samba/smb.conf/ibay-shared/20profile_default
+    dest: /etc/e-smith/templates/etc/samba/smb.conf/ibay-shared/20profile_default
     line: 'directory mask = 0775'
     insertafter: '^create mask'
     state: present
@@ -99,7 +99,7 @@
 
 - name: Configuring force create mode
   lineinfile:
-    dest: /etc/e-smith/templates-custom/etc/samba/smb.conf/ibay-shared/20profile_default
+    dest: /etc/e-smith/templates/etc/samba/smb.conf/ibay-shared/20profile_default
     line: 'force create mode = 0664'
     insertafter: '^directory mask'
     state: present
@@ -107,7 +107,7 @@
 
 - name: Configuring force directory mode
   lineinfile:
-    dest: /etc/e-smith/templates-custom/etc/samba/smb.conf/ibay-shared/20profile_default
+    dest: /etc/e-smith/templates/etc/samba/smb.conf/ibay-shared/20profile_default
     line: 'force directory mode = 0775'
     insertafter: '^force create mode'
     state: present


### PR DESCRIPTION
Hi all,
this should fix a painful regression which didn't allowed to use the shared folder correctly.

### Symptoms ###
Create a new subfolder inside the *shared* folder, then try to create a file inside the just created folder: you will receive a permission error.

### Notes ###
No workaround notes. 