### PR TITLE
Fixing broken geogebra signing for packages.

### DIFF
--- a/roles/preseed/tasks/repoconfig.yml
+++ b/roles/preseed/tasks/repoconfig.yml
@@ -35,3 +35,9 @@
     - epoptes-ppa-trusty.list
     - geogebra-stable.list
   become: yes
+
+- name: Pre-downloading geogebra GPG signature because of HTTPS
+  get_url:
+    url: "https://www.geogebra.net/linux/office@geogebra.org.gpg.key"
+    dest: "/var/lib/nethserver/ibay/ks/repoconfig/office_geogebra.gpg.key"
+  become: yes

--- a/roles/preseed/templates/preseed/aula-trusty.seed
+++ b/roles/preseed/templates/preseed/aula-trusty.seed
@@ -55,7 +55,7 @@ d-i 	apt-setup/local2/key 			string http://keyserver.ubuntu.com:11371/pks/lookup
 # Setup and enable geogebra repository
 d-i	apt-setup/local3/repository		string http://{{ execpath }}/www.geogebra.net/linux stable main
 d-i	apt-setup/local3/comment		string Geogebra Official repository
-d-i	apt-setup/local3/key			string http://www.geogebra.net/linux/office@geogebra.org.gpg.key.new
+d-i	apt-setup/local3/key			string http://{{ ansible_local.domain.serverfqdn }}/ks/repoconfig/office_geogebra.gpg.key
 
 # Time and date
 d-i	clock-setup/utc				boolean true

--- a/roles/preseed/templates/preseed/client-trusty.seed
+++ b/roles/preseed/templates/preseed/client-trusty.seed
@@ -55,7 +55,7 @@ d-i 	apt-setup/local2/key 			string http://keyserver.ubuntu.com:11371/pks/lookup
 # Setup and enable geogebra repository
 d-i	apt-setup/local3/repository		string http://{{ execpath }}/www.geogebra.net/linux stable main
 d-i	apt-setup/local3/comment		string Geogebra Official repository
-d-i	apt-setup/local3/key			string http://www.geogebra.net/linux/office@geogebra.org.gpg.key.new
+d-i	apt-setup/local3/key			string http://{{ ansible_local.domain.serverfqdn }}/ks/repoconfig/office_geogebra.gpg.key
 
 # Time and date
 d-i	clock-setup/utc				boolean true

--- a/roles/preseed/templates/preseed/docenti-trusty.seed
+++ b/roles/preseed/templates/preseed/docenti-trusty.seed
@@ -55,7 +55,7 @@ d-i 	apt-setup/local2/key 			string http://keyserver.ubuntu.com:11371/pks/lookup
 # Setup and enable geogebra repository
 d-i	apt-setup/local3/repository		string http://{{ execpath }}/www.geogebra.net/linux stable main
 d-i	apt-setup/local3/comment		string Geogebra Official repository
-d-i	apt-setup/local3/key			string http://www.geogebra.net/linux/office@geogebra.org.gpg.key.new
+d-i	apt-setup/local3/key			string http://{{ ansible_local.domain.serverfqdn }}/ks/repoconfig/office_geogebra.gpg.key
 
 # Time and date
 d-i	clock-setup/utc				boolean true


### PR DESCRIPTION
Since Geogebra people decided to change availability of PGP key for their packages (not available anymore on HTTP), we download it and offer to load it directly from the server instead that from the network.