### PR TITLE
Fixing issue #21: no changes to the wan0 interface

### DIFF
--- a/roles/nethcfg/defaults/main.yml
+++ b/roles/nethcfg/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-extnic: wan0
 intnic: lan0
 force_regen_ca: false
 force_ibay_shared: false

--- a/roles/nethcfg/tasks/network.yml
+++ b/roles/nethcfg/tasks/network.yml
@@ -1,9 +1,6 @@
 ---
 # Reconfiguring network interfaces
 
-- name: Configuring external NIC
-  shell: /sbin/e-smith/db networks setprop {{ extnic }} role red bootproto dhcp 
-
 - name: Configuring internal NIC
   shell: /sbin/e-smith/db networks setprop {{ intnic }} role green ipaddr {{ ansible_local.domain.serverip }} netmask {{ ansible_local.domain.servernetmask }}
 


### PR DESCRIPTION
No reconfiguration of the wan0 (external) interface has to be done during configuration: forcing to DHCP can be a problem in some situations. Fixes issue #21.